### PR TITLE
Minor documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
 # Personal dotfiles
 
+_Everything here is provided "as is", without warranty of any kind._
+
 ## Usage notes
 
 - assumes a GNU/Linux-style userland
 - [`home/`](home) contains files to be installed into the user home directory,
-  keeping those files separate from things needed to maintain and use the
-  repository; thus, [`.vscode/`](.vscode) contains Visual Studio Code
-  configuration pertinent to maintaining this repository and does _not_ contain
-  files to be installed into `~/.config/Code/User/`
+  separating them from things needed to maintain the repository, e.g. for Visual
+  Studio Code configuration:
+  - [`home/.config/Code/User/`](home/.config/Code/User) contains the files to
+    install into `~/.config/Code/User/`
+  - [`.vscode/`](.vscode) contains files specific to working in the `dotfiles`
+    repository workspace
 - [`install.sh`](install.sh) sets up the home directory
   - rather than symlink entire directories, individual files are symlinked after
     creating their directories, allowing finer control over which files are kept
     in version control
   - for better ergonomics, [`bin` scripts](home/bin) are symlinked without their
     extension; additionally, Python scripts are symlinked in kebab case (which
-    is easier to type) rather than the in-repoistory snake case (which is
+    is easier to type) rather than the in-repository snake case (which is
     `import`able)
 - some items assume the presence of other things (e.g. a script might assume
   that certain `.gitconfig` aliases are configured or that another script can be

--- a/home/bin/aws_as_role.py
+++ b/home/bin/aws_as_role.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+"""
+Run a command after assuming an IAM role.
+
+Your own credentials must have authorization to obtain temporary tokens
+from the AWS Security Token Service (STS) for the given role.
+"""
 
 from os import environ
 from typing import Dict, List, TypedDict, cast
@@ -39,14 +45,8 @@ def get_parser():
     from argparse import ArgumentParser
 
     # if changing this interface, review aws-as-profile's usage of aws-as-role
-    parser = ArgumentParser(
-        description="Run a command after assuming an IAM role.",
-        epilog="""
-            Your own credentials must have authorization to obtain temporary
-            tokens from the AWS Security Token Service (STS) for the given
-            role.
-        """,
-    )
+    description, epilog = __doc__.split("\n\n")
+    parser = ArgumentParser(description=description, epilog=epilog)
     parser.add_argument(
         "--profile",
         help="""

--- a/home/bin/aws_dynamodb_copy.py
+++ b/home/bin/aws_dynamodb_copy.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
+"""
+Copy all items from one DynamoDB table to another by scanning for its
+items, optionally applying a data transformation, and then batch writing
+all items.
 
+If your source table contains many items, you do not need to do any data
+transformations, and you can create a new destination table rather than
+use an existing one, consider restoring from a DynamoDB backup as an
+alternative.
+"""
 
 from typing import List, Optional
 
@@ -64,19 +73,8 @@ def main() -> int:
 def get_parser():
     from argparse import ArgumentParser
 
-    parser = ArgumentParser(
-        description="""
-            Copy all items from one DynamoDB table to another by scanning for
-            its items, optionally applying a data transformation, and then
-            batch writing all items.
-        """,
-        epilog="""
-            If your source table contains many items, you do not need to do any
-            data transformations, and you can create a new destination table
-            rather than use an existing one, consider restoring from a DynamoDB
-            backup as an alternative.
-        """,
-    )
+    description, epilog = __doc__.split("\n\n")
+    parser = ArgumentParser(description=description, epilog=epilog)
     parser.add_argument(
         "--source-consistent-scan",
         help="""

--- a/home/bin/aws_dynamodb_truncate.py
+++ b/home/bin/aws_dynamodb_truncate.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+"""
+Clear a DynamoDB table by scanning for its item keys and then batch
+deleting all items found.
+
+If your table contains many items, consider deleting the table as whole
+and creating it again as a cheaper/faster alternative.
+"""
 
 from typing import List, Optional
 
@@ -35,16 +42,8 @@ def main() -> int:
 def get_parser():
     from argparse import ArgumentParser
 
-    parser = ArgumentParser(
-        description="""
-            Clear a DynamoDB table by scanning for its item keys and then batch
-            deleting all items found.
-        """,
-        epilog="""
-            If your table contains many items, consider deleting the table as
-            whole and creating it again as a cheaper/faster alternative.
-        """,
-    )
+    description, epilog = __doc__.split("\n\n")
+    parser = ArgumentParser(description=description, epilog=epilog)
     parser.add_argument(
         "--profile",
         help="""

--- a/home/bin/aws_lambda_env.py
+++ b/home/bin/aws_lambda_env.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python3
+"""
+Given a Lambda function, display its environment variables or run a
+command with those environment variables set.
+
+Note that any command run will be using the AWS credentials of the user
+invoking the script (or no credentials at all if --no-auth-env is used);
+the command will not run with the permissions of the role used by a real
+invocation of the Lambda function.
+"""
 
 from sys import stderr
 
@@ -34,18 +43,8 @@ def main():
 def get_parser():
     from argparse import ArgumentParser
 
-    parser = ArgumentParser(
-        description="""
-            Given a Lambda function, display its environment variables or run a
-            command with those environment variables set.
-        """,
-        epilog="""
-            Note that any command run will be using the AWS credentials of the
-            user invoking the script (or no credentials at all if --no-auth-env
-            is used); the command will not run with the permissions of the role
-            used by a real invocation of the Lambda function.
-        """,
-    )
+    description, epilog = __doc__.split("\n\n")
+    parser = ArgumentParser(description=description, epilog=epilog)
     parser.add_argument(
         "--profile",
         help="""

--- a/home/bin/aws_log_retention.py
+++ b/home/bin/aws_log_retention.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+"""
+View or set retention policy across multiple log groups.
+
+This script can be helpful used in conjunction with "infrastructure as
+code" deployments that do not explicitly provision log retention
+policies, including Lambda@Edge functions that create their log groups
+across multiple regions.
+"""
 
 from argparse import ArgumentParser
 from os import getenv
@@ -32,15 +40,8 @@ def main():
 
 
 def get_parser():
-    parser = ArgumentParser(
-        description="View or set retention policy across multiple log groups.",
-        epilog="""
-            This script can be helpful used in conjunction with "infrastructure
-            as code" deployments that do not explicitly provision log retention
-            policies, including Lambda@Edge functions that create their log
-            groups across multiple regions.
-        """,
-    )
+    description, epilog = __doc__.split("\n\n")
+    parser = ArgumentParser(description=description, epilog=epilog)
     parser.add_argument(
         "--profile",
         help="""

--- a/home/bin/gh_super_linter.py
+++ b/home/bin/gh_super_linter.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+"""
+Run GitHub's Super-Linter locally using Docker.
+
+{LINTER_NAME} will be pulled and ran. See
+<https://github.com/github/super-linter/blob/master/docs/run-linter-locally.md>
+for more information.
+"""
 
 from collections import namedtuple
 from os import getcwd
@@ -23,14 +30,8 @@ def get_parser():
     from argparse import ArgumentParser
     from os.path import abspath, isdir
 
-    parser = ArgumentParser(
-        description="Run GitHub's Super-Linter locally using Docker.",
-        epilog=f"""
-            {LINTER_NAME} will be pulled and ran. See
-            <https://github.com/github/super-linter/blob/master/docs/run-linter-locally.md>
-            for more information.
-        """,
-    )
+    description, epilog = __doc__.format(**globals()).split("\n\n")
+    parser = ArgumentParser(description=description, epilog=epilog)
 
     def directory_path(value: str) -> str:
         value = abspath(value)

--- a/home/bin/gitalias-graph.sh
+++ b/home/bin/gitalias-graph.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+#
+# Display log output with a colored graph in the left gutter.
+#
+# Arguments to this script will be forwarded to `git log`, For bash completion
+# to work, `git graph` should be registered as a `log`-like script:
+#
+# [alias]
+# 	graph = !: git log && gitalias-graph
 
 set -euETo pipefail
 shopt -s inherit_errexit

--- a/home/bin/gitalias-sync.sh
+++ b/home/bin/gitalias-sync.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
-
-set -euETo pipefail
-shopt -s inherit_errexit
-
+#
 # Quickly save changes back to the remote, especially in notetaking-style repos.
 # Inspired by <https://gitjournal.io/support/#auto-syncing-from-the-desktop>,
 # but more conservative, with greater opportunities to confirm or bail out of
@@ -14,6 +11,9 @@ shopt -s inherit_errexit
 #
 # [alias]
 # 	sync = !: git commit && gitalias-sync
+
+set -euETo pipefail
+shopt -s inherit_errexit
 
 function msg() {
   echo


### PR DESCRIPTION
Notably, make sure all scripts have an explanation at the top.

For Python using `argparse`, get their help `description` and `epilog` from the module's `__doc__` to avoid repeating prose.