### PR TITLE
Run install.sh and test it during pull requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,11 +8,36 @@ on:
     branches: [master]
 
 jobs:
+  install:
+    name: Install checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2 # repository available as $GITHUB_WORKSPACE
+      - run: shellcheck install.sh test.sh
+
+      # These steps test that a fresh install actually works. To that end, do a
+      # couple things to make the environment more like a regular Ubuntu system
+      # and less like a GitHub Actions runner:
+      #
+      # - remove files that Ubuntu wouldn't normally ship to users (e.g. Ubuntu
+      #   normally sets up users with a `~/.profile` that does things like add
+      #   `~/bin` to the `PATH` and sourcing `~/.bashrc`; GitHub Actions also
+      #   has a `~/.bash_profile` which would prevent `~/.profile` from running)
+      # - run `test.sh` under a login `shell` so it can pickup `~/.profile` (and
+      #   thus have a correct `PATH` for accessing `~/bin` scripts); without
+      #   this, GitHub would run the script as `bash --noprofile --norc`, which
+      #   doesn't setup the `PATH` and doesn't exercise bash-related dotfiles
+
+      - run: rm ~/.bash_profile
+      - run: ./install.sh
+      - run: ./test.sh
+        shell: bash --login -eo pipefail -- {0}
+
   linter:
     name: Super-Linter checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2 # repository available as $GITHUB_WORKSPACE
+      - uses: actions/checkout@v2
       - uses: github/super-linter@v3.15.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for individual lint status

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Test if the user home directory appears to be setup correctly by running some
+# checks. Each command here is printed (`set -x`) and the script will exit
+# if something goes wrong (`set -euETo pipefail`, `shopt -s inherit_errexit`).
+
+set -euxETo pipefail
+shopt -s inherit_errexit
+
+test ! -e ~/bin/lib # `install.sh` should have skipped `home/bin/lib` directory
+aws-as-profile -h | grep -q '^usage: aws-as-profile '
+gh-super-linter --help | grep -q '^usage: gh-super-linter '
+
+test "$(git whoami | grep -cF dave@corpulent)" -eq 2


### PR DESCRIPTION
Adds a new `test.sh` that does some very (very very) basic checks to make sure the home directory seems to have been setup correctly.

During pull requests, run `install.sh` followed by `test.sh` to validate that the basics are okay.