### PR TITLE
Additional git aliases for routine operations

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -14,6 +14,7 @@
 ; additional examples, see:
 ; https://github.com/git/git/blob/master/contrib/completion/git-completion.bash
 
+	delete-merged-orphans = !: git branch && gitalias-delete-merged-orphans
 	graph = !: git log && gitalias-graph
 	staged = diff --staged
 	sync = !: git commit && gitalias-sync

--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -16,6 +16,7 @@
 
 	delete-merged-orphans = !: git branch && gitalias-delete-merged-orphans
 	graph = !: git log && gitalias-graph
+	reconcile = !: git commit && gitalias-reconcile
 	staged = diff --staged
 	sync = !: git commit && gitalias-sync
 	up = fetch --all --prune --tags

--- a/home/bin/gitalias-delete-merged-orphans.sh
+++ b/home/bin/gitalias-delete-merged-orphans.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Delete all local branches that
+#
+# - have been merged to HEAD
+#   *and*
+# - used to have an upstream (pull) remote that is now gone
+#   *and*
+# - used to have a push remote that is now gone.
+#
+# Arguments to this script will be forwarded after `git branch --list` (e.g. to
+# allow further limiting of which branches are eligible for deletion). For bash
+# completion to work, `git delete-merged-orphans` should be registered as a
+# `branch`-like script:
+#
+# [alias]
+# 	delete-merged-orphans = !: git branch && gitalias-delete-merged-orphans
+
+set -euETo pipefail
+shopt -s inherit_errexit
+
+readonly listFormat='%(upstream:track):%(push:track):%(HEAD):%(refname:strip=2)'
+readonly isEligible='^\[gone\]:\[gone\]: :'
+readonly branchField=4
+
+git branch --list --merged HEAD --format "$listFormat" "$@" |
+  grep "$isEligible" |
+  cut --delimiter ':' --fields "${branchField}-" |
+  while read -r branch; do
+    git branch --delete "$branch"
+  done

--- a/home/bin/gitalias-delete-merged-orphans.sh
+++ b/home/bin/gitalias-delete-merged-orphans.sh
@@ -15,6 +15,10 @@
 #
 # [alias]
 # 	delete-merged-orphans = !: git branch && gitalias-delete-merged-orphans
+#
+# This script returns a non-zero status if there are no branches eligible to
+# delete (because of `grep` in the pipeline combined with `set -o pipefail`).
+# If changing this behavior, see `gitalias-sync.sh`, which checks the status.
 
 set -euETo pipefail
 shopt -s inherit_errexit

--- a/home/bin/gitalias-delete-merged-orphans.sh
+++ b/home/bin/gitalias-delete-merged-orphans.sh
@@ -2,7 +2,7 @@
 #
 # Delete all local branches that
 #
-# - have been merged to HEAD
+# - have been merged to HEAD but aren't the current HEAD branch itself
 #   *and*
 # - used to have an upstream (pull) remote that is now gone
 #   *and*

--- a/home/bin/gitalias-reconcile.sh
+++ b/home/bin/gitalias-reconcile.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Quickly save changes back to the remote, especially in notetaking-style repos.
+# Inspired by <https://gitjournal.io/support/#auto-syncing-from-the-desktop>,
+# but more conservative, with greater opportunities to confirm or bail out of
+# what is happening.
+#
+# Arguments to this script will be forwarded along after `git commit --patch`,
+# e.g. `git reconcile -m <msg>` would become `git commit --patch -m <msg>`. For
+# bash completion to work, `git reconcile` should be registered as a
+# `commit`-like script:
+#
+# [alias]
+# 	reconcile = !: git commit && gitalias-reconcile
+
+set -euETo pipefail
+shopt -s inherit_errexit
+
+repoToplevel="$(git rev-parse --show-toplevel)"
+cd "$repoToplevel"
+
+git symbolic-ref HEAD >/dev/null # we want to error out if off-branch
+repoStatus="$(git status --porcelain)"
+
+if [ "${#repoStatus}" -ne 0 ]; then # dirty working directory
+  mapfile -t newFiles < <(echo "$repoStatus" | grep '^?? ' | cut -d' ' -f2-)
+  for newFile in "${newFiles[@]}"; do
+    read -rp "Add $newFile? "
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      git stage --intent-to-add --verbose -- "$newFile"
+    fi
+  done
+
+  # Note that `git commit` returns a non-zero status if nothing is commited.
+  git commit --patch "$@" || true
+
+  echo
+  echo 'Stashing and then rebasing this branch on remote, if needed'
+  git pull --autostash --rebase --verbose
+else # clean working directory
+  echo
+  echo 'Rebasing this branch on remote, if needed'
+  git pull --rebase --verbose
+fi
+
+echo
+echo 'Updating remote with local changes'
+git push --verbose


### PR DESCRIPTION
Add `git delete-merged-orphans` alias, make it part of `git sync`, but split off a more specific (and quicker) `git reconcile` command from `git sync`.
