### PR TITLE
Add new update-bash-completion script

### DIFF
--- a/home/bin/update-bash-completion.sh
+++ b/home/bin/update-bash-completion.sh
@@ -43,7 +43,8 @@ shopt -s inherit_errexit
 readonly systemDirectory=/usr/share/bash-completion/completions
 readonly userDirectory="${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions"
 
-if [ ! -d "$systemDirectory" ]; then
+if [ ! -d "$systemDirectory" ] ||
+  [ "$(find "$systemDirectory" -maxdepth 1 -type f | wc --lines)" -lt 50 ]; then
   echo "system completions doesn't seem to live in $systemDirectory here" >&2
   exit 1
 fi

--- a/home/bin/update-bash-completion.sh
+++ b/home/bin/update-bash-completion.sh
@@ -59,6 +59,8 @@ installUserCompletion() {
       if [ -e "$userFile" ]; then
         echo "warning: $systemFile and $userFile both exist" >&2
       fi
+    elif [ -L "$userFile" ]; then
+      echo "warning: refusing to overwrite $userFile symlink" >&2
     else
       echo "$* >$userFile"
       "$@" >"$userFile"

--- a/home/bin/update-bash-completion.sh
+++ b/home/bin/update-bash-completion.sh
@@ -41,7 +41,7 @@ shopt -s inherit_errexit
 # lazy loading based on the command being used, so I think that it's the better
 # method, whereas `~/.bash_completion` is sourced in its entirety every time.
 readonly systemDirectory=/usr/share/bash-completion/completions
-readonly userDirectory=~/.local/share/bash-completion/completions
+readonly userDirectory="${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions"
 
 if [ ! -d "$systemDirectory" ]; then
   echo "system completions doesn't seem to live in $systemDirectory here" >&2

--- a/home/bin/update-bash-completion.sh
+++ b/home/bin/update-bash-completion.sh
@@ -45,7 +45,7 @@ readonly userDirectory="${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/com
 
 if [ ! -d "$systemDirectory" ] ||
   [ "$(find "$systemDirectory" -maxdepth 1 -type f | wc --lines)" -lt 50 ]; then
-  echo "system completions doesn't seem to live in $systemDirectory here" >&2
+  echo "system completions do not seem to live in $systemDirectory" >&2
   exit 1
 fi
 mkdir --parents --verbose "$userDirectory"

--- a/home/bin/update-bash-completion.sh
+++ b/home/bin/update-bash-completion.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# While `apt`-installed tools generally neatly setup bash completion by dropping
+# a managed file into `/usr/share/bash-completion/completions`, user-installed
+# tools usually aren't so nice.
+#
+# Some such user-installed tools recommend enabling their bash completion by
+# `source`/`.`/`eval`ing the output of one of their commands during shell
+# initialization in `.bashrc`. Some tools are slow, though, and executing them
+# to get their bash completion output takes time, even if the tool won't be used
+# in a particular bash session.
+#
+# This script intends to allow the bash completion output of such tools to be
+# obtained ahead of time and placed in the user completion directory so they do
+# not need to take initialization time unless actually used. Then, it can be run
+# at any time to freshen those bash completion files as new versions of tools
+# are released.
+#
+# What this script does not handle, however, and shouldn't need to handle:
+#
+# - Tools which are `complete`-compatible, which do not slow down shell
+#   initialization and can go into `.bashrc`, e.g. the AWS CLI (`aws`) has a
+#   `aws_completer` setup something like this: `complete -C ~/aws_completer aws`
+# - Tools that come with a pre-baked bash completion file as part of their code;
+#   these can just be symlinked into the user bash completion directory, e.g.
+#   `ln -s $NVM_DIR/bash_completion nvm` while in the user completion directory
+
+set -euETo pipefail
+shopt -s inherit_errexit
+
+# On at least Ubuntu 20.04, `/usr/share/bash-completion/bash_completion` is
+# capable of picking up user completions in two different places:
+#
+# - a directory called `~/.local/share/bash-completion/completions` (or
+#   `$XDG_DATA_HOME/bash-completion/completions` if `$XDG_DATA_HOME` is set),
+#   with each individual file named after the command needing completion,
+#   similar to the system-wide `/usr/share/bash-completion/completions`
+# - a file called `~/.bash_completion`
+#
+# The former is wrapped up in a function called `__load_completion` which does
+# lazy loading based on the command being used, so I think that it's the better
+# method, whereas `~/.bash_completion` is sourced in its entirety every time.
+readonly systemDirectory=/usr/share/bash-completion/completions
+readonly userDirectory=~/.local/share/bash-completion/completions
+
+if [ ! -d "$systemDirectory" ]; then
+  echo "system completions doesn't seem to live in $systemDirectory here" >&2
+  exit 1
+fi
+mkdir --parents --verbose "$userDirectory"
+
+installUserCompletion() {
+  if command -v "$1" >/dev/null; then
+    local systemFile="$systemDirectory/$1"
+    local userFile="$userDirectory/$1"
+
+    if [ -e "$systemFile" ]; then
+      echo "$1 already provided by system-wide $systemFile"
+      if [ -e "$userFile" ]; then
+        echo "warning: $systemFile and $userFile both exist" >&2
+      fi
+    else
+      echo "$* >$userFile"
+      "$@" >"$userFile"
+    fi
+  else
+    echo "$1 is not installed"
+  fi
+}
+
+installUserCompletion flutter bash-completion
+installUserCompletion gh completion -s bash
+installUserCompletion kubectl completion bash
+installUserCompletion minikube completion bash


### PR DESCRIPTION
Provide a way to automatically manage user-installed tools whose bash completion is enabled by sourcing the output of some subcommand of the tool itself.