### PR TITLE
Some additional git reconcile tweaks

### DIFF
--- a/home/bin/gitalias-reconcile.sh
+++ b/home/bin/gitalias-reconcile.sh
@@ -5,10 +5,10 @@
 # but more conservative, with greater opportunities to confirm or bail out of
 # what is happening.
 #
-# Arguments to this script will be forwarded along after `git commit --patch`,
-# e.g. `git reconcile -m <msg>` would become `git commit --patch -m <msg>`. For
-# bash completion to work, `git reconcile` should be registered as a
-# `commit`-like script:
+# Arguments to this script will be forwarded along after `git commit`, e.g.
+# `git reconcile -pm <msg>` would become `git commit -pm <msg>`. For bash
+# completion to work, `git reconcile` should be registered as a `commit`-like
+# script:
 #
 # [alias]
 # 	reconcile = !: git commit && gitalias-reconcile
@@ -32,7 +32,7 @@ if [ "${#repoStatus}" -ne 0 ]; then # dirty working directory
   done
 
   # Note that `git commit` returns a non-zero status if nothing is commited.
-  git commit --patch "$@" || true
+  git commit "$@" || true
 
   echo
   echo 'Stashing and then rebasing this branch on remote, if needed'

--- a/home/bin/gitalias-reconcile.sh
+++ b/home/bin/gitalias-reconcile.sh
@@ -41,7 +41,7 @@ if [ "${#repoStatus}" -ne 0 ]; then # dirty working directory
 fi
 
 echo
-if git push --verbose; then
+if git push --verbose; then # fails if remote is ahead, even if nothing to push
   exit 0
 fi
 

--- a/home/bin/gitalias-reconcile.sh
+++ b/home/bin/gitalias-reconcile.sh
@@ -32,17 +32,19 @@ if [ "${#repoStatus}" -ne 0 ]; then # dirty working directory
   done
 
   # Note that `git commit` returns a non-zero status if nothing is commited.
-  git commit "$@" || true
-
   echo
-  echo 'Stashing and then rebasing this branch on remote, if needed'
-  git pull --autostash --rebase --verbose
-else # clean working directory
-  echo
-  echo 'Rebasing this branch on remote, if needed'
-  git pull --rebase --verbose
+  git commit "$@" || echo 'continuing without new commit'
 fi
 
 echo
-echo 'Updating remote with local changes'
+if git push --verbose; then
+  exit 0
+fi
+
+echo
+echo 'Stashing and then rebasing this branch on remote'
+git pull --autostash --rebase --verbose
+
+echo
+echo 'Trying again to update remote'
 git push --verbose

--- a/home/bin/gitalias-reconcile.sh
+++ b/home/bin/gitalias-reconcile.sh
@@ -23,13 +23,17 @@ git symbolic-ref HEAD >/dev/null # we want to error out if off-branch
 repoStatus="$(git status --porcelain)"
 
 if [ "${#repoStatus}" -ne 0 ]; then # dirty working directory
-  mapfile -t newFiles < <(echo "$repoStatus" | grep '^?? ' | cut -d' ' -f2-)
-  for newFile in "${newFiles[@]}"; do
-    read -rp "Add $newFile? "
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      git stage --intent-to-add --verbose -- "$newFile"
-    fi
-  done
+  # Hacky (should parse arguments for real), but, if an interactive commit or
+  # adding all files, then there is probably interest in adding untracked files.
+  if [[ "$*" =~ (^| )(-[a-zA-Z]*[ap]|--(all|interactive|patch)) ]]; then
+    mapfile -t newFiles < <(echo "$repoStatus" | grep '^?? ' | cut -d' ' -f2-)
+    for newFile in "${newFiles[@]}"; do
+      read -rp "Add $newFile? "
+      if [[ $REPLY =~ ^[Yy]$ ]]; then
+        git stage --intent-to-add --verbose -- "$newFile"
+      fi
+    done
+  fi
 
   # Note that `git commit` returns a non-zero status if nothing is commited.
   echo

--- a/home/bin/gitalias-reconcile.sh
+++ b/home/bin/gitalias-reconcile.sh
@@ -46,7 +46,7 @@ if git push --verbose; then # fails if remote is ahead, even if nothing to push
 fi
 
 echo
-echo 'Stashing and then rebasing this branch on remote'
+echo 'Updating this branch from remote' # maybe stashing/rebasing, but maybe not
 git pull --autostash --rebase --verbose
 
 echo


### PR DESCRIPTION
Do not assume patchy `git reconcile` and attempt to push in `git reconcile` before doing a rebase on the remote.
