### PR TITLE
Expand sanity checks in test.sh

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # repository available as $GITHUB_WORKSPACE
-      - run: shellcheck install.sh test.sh
+      - run: shellcheck *.sh
 
       # These steps test that a fresh install actually works. To that end, do a
       # couple things to make the environment more like a regular Ubuntu system

--- a/install.sh
+++ b/install.sh
@@ -65,3 +65,6 @@ echo "needs reconciling: $copyCount"
 echo "cleanly installed: $linkCount"
 
 test "$failCount" -eq 0 && test "$copyCount" -eq 0
+
+echo
+echo 'You can run test.sh as a sanity check of the installation.'

--- a/test-interactive.sh
+++ b/test-interactive.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# The tests in this file inspect aliases and shell functions, so it's intended
+# to be run inside an interactive shell (e.g. `bash -i test-interactive.sh`);
+# the shebang above is just so tools recognize that this is a bash shell script.
+
+set -euETo pipefail
+shopt -s inherit_errexit
+
+case $- in
+*i*) ;;
+*)
+  echo 'test-interactive.sh must be run as if an interactive shell.' >&2
+  exit 1
+  ;;
+esac
+
+set -x
+
+# Verify everything in bin is executable and we aren't accidentally conflicting
+# with a system-wide bin command, an alias, or some shell built-in.
+for path in ~/bin/*; do
+  test -x "$path"
+
+  command=$(basename "$path")
+  test "$(type -ap "$command")" == "$HOME/bin/$command"
+  test "$(type -at "$command")" == 'file'
+done

--- a/test.sh
+++ b/test.sh
@@ -19,7 +19,10 @@ test ! -e ~/bin/lib # `install.sh` should have skipped `home/bin/lib` directory
 # with a system-wide bin command, an alias, or some shell built-in.
 for path in ~/bin/*; do
   test -x "$path"
-  test "$(type -ap "$(basename "$path")" | wc --lines)" -eq 1
+
+  command=$(basename "$path")
+  test "$(type -ap "$command" | wc --lines)" -eq 1
+  test "$(type -at "$command")" == 'file'
 done
 
 aws-as-profile -h | grep -q '^usage: aws-as-profile '

--- a/test.sh
+++ b/test.sh
@@ -17,3 +17,5 @@ aws-as-profile -h | grep -q '^usage: aws-as-profile '
 gh-super-linter --help | grep -q '^usage: gh-super-linter '
 
 test "$(git whoami | grep -cF dave@corpulent)" -eq 2
+
+echo 'Everything looks okay!'

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,16 @@ on_error() {
   echo 'Test suite failed; manually check your installation.' >&2
 }
 
+test -d ~/bin
 test ! -e ~/bin/lib # `install.sh` should have skipped `home/bin/lib` directory
+
+# Verify everything in bin is executable and we aren't accidentally conflicting
+# with a system-wide bin command, an alias, or some shell built-in.
+for path in ~/bin/*; do
+  test -x "$path"
+  test "$(type -ap "$(basename "$path")" | wc --lines)" -eq 1
+done
+
 aws-as-profile -h | grep -q '^usage: aws-as-profile '
 gh-super-linter --help | grep -q '^usage: gh-super-linter '
 

--- a/test.sh
+++ b/test.sh
@@ -23,20 +23,10 @@ set -x
 
 test -d ~/bin
 test ! -e ~/bin/lib # `install.sh` should have skipped `home/bin/lib` directory
-
-# Verify everything in bin is executable and we aren't accidentally conflicting
-# with a system-wide bin command, an alias, or some shell built-in.
-for path in ~/bin/*; do
-  test -x "$path"
-
-  command=$(basename "$path")
-  test "$(type -ap "$command")" == "$HOME/bin/$command"
-  test "$(type -at "$command")" == 'file'
-done
+bash -i test-interactive.sh
 
 aws-as-profile -h | grep -q '^usage: aws-as-profile '
 gh-super-linter --help | grep -q '^usage: gh-super-linter '
-
 test "$(git whoami | grep -cF dave@corpulent)" -eq 2
 
 echo 'Everything looks okay!'

--- a/test.sh
+++ b/test.sh
@@ -4,13 +4,22 @@
 # checks. Each command here is printed (`set -x`) and the script will exit
 # if something goes wrong (`set -euETo pipefail`, `shopt -s inherit_errexit`).
 
-set -euxETo pipefail
+set -euETo pipefail
 shopt -s inherit_errexit
+
+if ! [[ ":$PATH:" == *":$HOME/bin:"* ]]; then
+  echo "$HOME/bin is absent from the user PATH, which is currently:" >&2
+  echo "$PATH" >&2
+  echo >&2
+  echo 'A logout/login cycle might be needed for ~/.profile to add it' >&2
+  exit 1
+fi
 
 trap on_error ERR
 on_error() {
   echo 'Test suite failed; manually check your installation.' >&2
 }
+set -x
 
 test -d ~/bin
 test ! -e ~/bin/lib # `install.sh` should have skipped `home/bin/lib` directory

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ for path in ~/bin/*; do
   test -x "$path"
 
   command=$(basename "$path")
-  test "$(type -ap "$command" | wc --lines)" -eq 1
+  test "$(type -ap "$command")" == "$HOME/bin/$command"
   test "$(type -at "$command")" == 'file'
 done
 

--- a/test.sh
+++ b/test.sh
@@ -7,6 +7,11 @@
 set -euxETo pipefail
 shopt -s inherit_errexit
 
+trap on_error ERR
+on_error() {
+  echo 'Test suite failed; manually check your installation.' >&2
+}
+
 test ! -e ~/bin/lib # `install.sh` should have skipped `home/bin/lib` directory
 aws-as-profile -h | grep -q '^usage: aws-as-profile '
 gh-super-linter --help | grep -q '^usage: gh-super-linter '


### PR DESCRIPTION
More importantly, check that nothing in `bin` conflicts with a built-in alias, system-wide command, or shell alias.