### PR TITLE
Slightly improve robustness of interactive test

### DIFF
--- a/test-interactive.sh
+++ b/test-interactive.sh
@@ -23,6 +23,9 @@ for path in ~/bin/*; do
   test -x "$path" # will also fail on a dangling symlink
 
   command=$(basename "$path")
-  test "$(type -ap "$command")" == "$HOME/bin/$command"
-  test "$(type -at "$command")" == 'file'
+
+  # If the user path contains ~/bin multiple times, then `type -a` will also
+  # output multiple times, so `sort --unique` is used here to de-duplicate.
+  test "$(type -ap "$command" | sort --unique)" == "$HOME/bin/$command"
+  test "$(type -at "$command" | sort --unique)" == 'file'
 done

--- a/test-interactive.sh
+++ b/test-interactive.sh
@@ -20,7 +20,7 @@ set -x
 # Verify everything in bin is executable and we aren't accidentally conflicting
 # with a system-wide bin command, an alias, or some shell built-in.
 for path in ~/bin/*; do
-  test -x "$path"
+  test -x "$path" # will also fail on a dangling symlink
 
   command=$(basename "$path")
   test "$(type -ap "$command")" == "$HOME/bin/$command"


### PR DESCRIPTION
Specifically, tolerate multiple ~/bin in user path, which can happen under certain situations.
