### PR TITLE
More adventures in GitHub Codespaces, keybindings edition

### DIFF
--- a/home/.config/Code/User/keybindings.json
+++ b/home/.config/Code/User/keybindings.json
@@ -1,3 +1,7 @@
+/**
+ * In the GitHub Codespaces environment, this file currently cannot be made
+ * available via a file system symlink. See dotfiles `install.sh`.
+ */
 [
   /** Open URLs or navigate between files */
   {

--- a/home/.config/Code/User/keybindings.json
+++ b/home/.config/Code/User/keybindings.json
@@ -1,0 +1,22 @@
+[
+  /** Open URLs or navigate between files */
+  {
+    "key": "alt+enter",
+    "command": "editor.action.openLink",
+    "when": "editorFocus && !findWidgetVisible"
+  },
+
+  /** Unneeded and conflicts w/ one of the "add cursor below" keybindings */
+  {
+    "key": "shift+alt+down",
+    "command": "-markdown.extension.onCopyLineDown" /* yzhang.markdown-all-in-one */,
+    "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && editorLangId == 'markdown'"
+  },
+
+  /** Unneeded and conflicts w/ one of the "add cursor above" keybindings */
+  {
+    "key": "shift+alt+up",
+    "command": "-markdown.extension.onCopyLineUp" /* yzhang.markdown-all-in-one */,
+    "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && editorLangId == 'markdown'"
+  }
+]


### PR DESCRIPTION
Introduce VS Code keybindings.json and then add documentation for current limitations in Codespaces without using Settings Sync.
