### PR TITLE
Add update-pip-user-packages script

### DIFF
--- a/home/bin/update-bash-completion.sh
+++ b/home/bin/update-bash-completion.sh
@@ -16,9 +16,13 @@
 # at any time to freshen those bash completion files as new versions of tools
 # are released.
 #
-# Note that some tools come with pre-baked bash completion files in their code;
-# these can just be symlinked into the user bash completion directory, e.g.
-# `ln -s $NVM_DIR/bash_completion nvm` while in the user completion directory
+# Note that some user-installed tools come with pre-baked bash completion files
+# with their packaging or code but might not correctly install themselves; these
+# can just be symlinked while in the user completion directory, e.g.:
+#
+# - `ln -s $NVM_DIR/bash_completion nvm` for the Node Version Manager
+# - `ln -s ~/.local/etc/bash_completion.d/xxx.bash-completion xxx` for some
+#   pip-packaged `--user` installed CLI tools
 
 set -euETo pipefail
 shopt -s inherit_errexit

--- a/home/bin/update-pip-user-packages.sh
+++ b/home/bin/update-pip-user-packages.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Do an upgrade of all pip packages that were directly installed (i.e. not as a
+# dependency) in "user-site" (i.e. with `--user`; on typical Ubuntu installs,
+# these are libraries installed to `~/.local/lib/python3.x/site-packages/` and
+# command-line tools installed to `~/.local/bin`).
+
+set -euETo pipefail
+shopt -s inherit_errexit
+
+readonly pip=pip3
+readonly expectedPip=/usr/bin/$pip
+
+if ! command -v "$pip" >/dev/null; then
+  echo "The $pip tool is not installed here." >&2
+  exit 1
+fi
+
+readonly actualPip=$(command -v "$pip")
+
+if ! [ "$actualPip" == "$expectedPip" ]; then
+  echo "The current $pip tool is $actualPip rather than $expectedPip." >&2
+  echo "If inside of a virtualenv, deactivate it before running $0." >&2
+  exit 1
+fi
+
+mapfile -t packages \
+  < <("$pip" list --user --not-required --format=freeze | sed 's/==.*$//')
+
+if ! [ "${#packages[@]}" -gt 0 ]; then
+  echo "There does not seem to be any user packages installed via $pip." >&2
+  exit 1
+fi
+
+"$pip" install --user --upgrade -- "${packages[@]}"

--- a/home/bin/update-pip-user-packages.sh
+++ b/home/bin/update-pip-user-packages.sh
@@ -2,8 +2,9 @@
 #
 # Do an upgrade of all pip packages that were directly installed (i.e. not as a
 # dependency) in "user-site" (i.e. with `--user`; on typical Ubuntu installs,
-# these are libraries installed to `~/.local/lib/python3.x/site-packages/` and
-# command-line tools installed to `~/.local/bin`).
+# these are libraries installed to `~/.local/lib/python3.x/site-packages/`,
+# command-line tools installed to `~/.local/bin`, and less commonly, ancillary
+# files placed into `~/.local/etc`).
 
 set -euETo pipefail
 shopt -s inherit_errexit


### PR DESCRIPTION
Make it easy to upgrade Python packages commonly installed as user-site
packages (like `black`, `boto3`, and others).
