### PR TITLE
Get settings.json working again on GA version of Codespaces

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,8 +59,7 @@ done < <(git ls-tree -rz --name-only HEAD) # only use committed files
 echo
 
 if [ "${CODESPACES-false}" == "true" ]; then
-  # GitHub Codespaces is still in preview. These tweaks worked and these notes
-  # were accurate as of March 2021, but things can still change...
+  # These tweaks worked and these notes were accurate as of September 2021.
   echo 'Codespaces-specific adjustments:'
 
   # Today's stock .gitconfig on Codespaces (verified by this md5sum check) just

--- a/install.sh
+++ b/install.sh
@@ -62,8 +62,9 @@ if [ "${CODESPACES-false}" == "true" ]; then
   # These tweaks worked and these notes were accurate as of September 2021.
   echo 'Codespaces-specific adjustments:'
 
-  # Today's stock .gitconfig on Codespaces (verified by this md5sum check) just
-  # contains a core.editor setting I don't need, so use my .gitconfig instead.
+  # The .gitconfig on the pre-GA Codespaces (verified by this md5sum check) just
+  # contained a core.editor setting I didn't need, so could use .gitconfig from
+  # dotfiles instead. This doesn't trip anymore in the GA version of Codespaces.
   if [ "$(md5sum <.gitconfig)" == "43ba1caca81a816ae18ac0857ad83b53  -" ]; then
     echo '- discarding Codespaces-provided .gitconfig for dotfiles-provided one'
     git checkout .gitconfig
@@ -81,9 +82,9 @@ if [ "${CODESPACES-false}" == "true" ]; then
   # The desktop-standard `~/.config/Code/User/settings.json` from the dotfiles
   # is not "currently" used.
   #
-  # Alternatively, Settings Sync (which itself is still in preview) could be
-  # used for these settings, probably still keeping them version-controlled here
-  # via regular desktop machines that don't use the IndexedDB API for storage.
+  # Alternatively, Settings Sync could be used for these settings, probably
+  # still keeping them version-controlled in the dotfiles repository via regular
+  # desktop machines that don't use the IndexedDB API for storage.
   readonly codespacesSettings=~/.vscode-remote/data/Machine
   readonly dotfilesSettings=.config/Code/User
   if [ -d "$codespacesSettings" ] && [ ! -L "$codespacesSettings" ]; then

--- a/install.sh
+++ b/install.sh
@@ -91,11 +91,12 @@ if [ "${CODESPACES-false}" == "true" ]; then
   # used for these settings, probably still keeping them version-controlled here
   # via regular desktop machines that don't use the IndexedDB API for storage.
   readonly codespacesSettings=~/.vscode-remote/data/Machine
+  readonly dotfilesSettings=.config/Code/User
   if [ -d "$codespacesSettings" ] && [ ! -L "$codespacesSettings" ] &&
     [ ! -e "$codespacesSettings/settings.json" ]; then
     echo -n "- linking machine settings to dotfiles: "
     ln --relative --symbolic --verbose \
-      .config/Code/User/settings.json "$codespacesSettings/settings.json"
+      "$dotfilesSettings/settings.json" "$codespacesSettings/settings.json"
   fi
 
   # Likewise, Visual Studio Code in Codespaces doesn't read the desktop-standard

--- a/install.sh
+++ b/install.sh
@@ -82,21 +82,21 @@ if [ "${CODESPACES-false}" == "true" ]; then
   # The desktop-standard `~/.config/Code/User/settings.json` from the dotfiles
   # is not "currently" used.
   #
-  # However, because the "machine"/"remote" one actually persists to disk and
-  # because it doesn't initially exist unless `devcontainer.json` is used, a
-  # symlink can just be created from the "machine"/"remote" settings location to
-  # the dotfiles version.
-  #
   # Alternatively, Settings Sync (which itself is still in preview) could be
   # used for these settings, probably still keeping them version-controlled here
   # via regular desktop machines that don't use the IndexedDB API for storage.
   readonly codespacesSettings=~/.vscode-remote/data/Machine
   readonly dotfilesSettings=.config/Code/User
-  if [ -d "$codespacesSettings" ] && [ ! -L "$codespacesSettings" ] &&
-    [ ! -e "$codespacesSettings/settings.json" ]; then
-    echo -n "- linking machine settings to dotfiles: "
-    ln --relative --symbolic --verbose \
-      "$dotfilesSettings/settings.json" "$codespacesSettings/settings.json"
+  if [ -d "$codespacesSettings" ] && [ ! -L "$codespacesSettings" ]; then
+    if [ -e "$codespacesSettings/settings.json" ]; then
+      echo 'TODO'
+    else
+      # "machine"/"remote" settings don't already exist, so symlink can just be
+      # created from "machine"/"remote" settings location to dotfiles version
+      echo -n "- linking machine settings to dotfiles: "
+      ln --relative --symbolic --verbose \
+        "$dotfilesSettings/settings.json" "$codespacesSettings/settings.json"
+    fi
   fi
 
   # Likewise, Visual Studio Code in Codespaces doesn't read the desktop-standard


### PR DESCRIPTION
Basically, merge settings keys if the settings file already exists, which it does on the now-GA version of Codespaces.
