### PR TITLE
Drop WSL support

### DIFF
--- a/home/.bash_aliases
+++ b/home/.bash_aliases
@@ -25,18 +25,8 @@ alias npx='npx --no-install'
 #   directory in the default file browser
 # - `open` with more than one argument runs `xdg-open` multiple times, once for
 #   each argument, to allow opening multiple files (or URLs) simultaneously
-#
-# Under WSL, expects a `wsl-open` wrapper script instead of `xdg-open`. There
-# are at least two implementations, e.g. <https://github.com/4U6U57/wsl-open>,
-# which can be `git clone`d and then symlinked into `~/bin` for this to work
-# (this particular sample `wsl-open` also features flags that wrap `xdg-mime`
-# and can manipulate `~/.mailcap` so that `xdg-open` itself could work on a WSL
-# with `xdg-utils` installed, but the `open` here doesn't rely on or use that).
 function open() {
   local opener=xdg-open
-  if [[ -v WSLENV ]]; then
-    opener=wsl-open
-  fi
 
   if [ $# -eq 0 ]; then
     "$opener" .

--- a/home/.bash_aliases
+++ b/home/.bash_aliases
@@ -49,20 +49,7 @@ function open-terminal() {
     fi
   done
 
-  if [[ -v WSLENV ]]; then
-    # See <https://docs.microsoft.com/windows/terminal/command-line-arguments>.
-    # Switches to `/mnt/c` only to avoid `cmd.exe` whining about UNC paths.
-    local wslPath
-    if [[ $# -eq 0 ]]; then
-      wslPath=$(wslpath -w "$PWD")
-      (cd /mnt/c && cmd.exe /c wt.exe -d "$wslPath")
-    else
-      for arg in "$@"; do
-        wslPath=$(wslpath -w "$arg")
-        (cd /mnt/c && cmd.exe /c wt.exe -d "$wslPath")
-      done
-    fi
-  elif [[ $# -eq 0 ]]; then
+  if [[ $# -eq 0 ]]; then
     x-terminal-emulator
   else
     for arg in "$@"; do

--- a/home/.bash_behavior
+++ b/home/.bash_behavior
@@ -70,18 +70,6 @@ if [[ ! -v CODESPACES ]]; then
   fi
 fi
 
-# Try to use `keychain` as an `ssh-agent` wrapper if we're running under WSL
-# without another SSH agent running. If any keys exist in `~/.ssh`, pass them as
-# positionals to `keychain`. This is usually already wired up on regular Ubuntu
-# by the desktop environment to the login user's keyring.
-if [[ -v WSLENV && ! -v SSH_AGENT_PID && ! -v SSH_AUTH_SOCK && -d ~/.ssh ]] &&
-  command -v keychain &>/dev/null; then
-  # shellcheck source=/dev/null
-  find ~/.ssh -name '*.pub' -prune -o -type f -name 'id_*' -print0 |
-    xargs -0 -- keychain --agents ssh -- &&
-    source "$HOME/.keychain/$HOSTNAME-sh"
-fi
-
 # Given a regular bash prompt ending in '$ ' that doesn't already try to do
 # something git-related, if we have `__git_ps1` *or* it appears that we *will*
 # have it (as on Ubuntu, where `/etc/bash_completion.d/git-prompt` sources

--- a/home/.config/Code/User/keybindings.json
+++ b/home/.config/Code/User/keybindings.json
@@ -12,39 +12,6 @@
     "when": "editorFocus && !findWidgetVisible"
   },
 
-  // Bring some of the default Linux keybindings to other platforms ////////////
-
-  {
-    "key": "ctrl+shift+alt+down",
-    "command": "editor.action.copyLinesDownAction",
-    "when": "editorTextFocus && !editorReadonly"
-  },
-  {
-    "key": "ctrl+shift+alt+up",
-    "command": "editor.action.copyLinesUpAction",
-    "when": "editorTextFocus && !editorReadonly"
-  },
-  {
-    "key": "ctrl+shift+down",
-    "command": "editor.action.insertCursorBelow",
-    "when": "editorTextFocus"
-  },
-  {
-    "key": "ctrl+shift+up",
-    "command": "editor.action.insertCursorAbove",
-    "when": "editorTextFocus"
-  },
-  {
-    "key": "shift+alt+down",
-    "command": "editor.action.insertCursorBelow",
-    "when": "editorTextFocus"
-  },
-  {
-    "key": "shift+alt+up",
-    "command": "editor.action.insertCursorAbove",
-    "when": "editorTextFocus"
-  },
-
   // Unneeded/unwanted keybindings from extensions /////////////////////////////
 
   /** Conflicts w/ one of the "add cursor below" keybindings */

--- a/install.sh
+++ b/install.sh
@@ -139,26 +139,6 @@ if [ "${CODESPACES-false}" == "true" ]; then
   echo
 fi
 
-# WSL-specific installation tweaks
-if [[ -v WSLENV ]]; then
-  if [[ -d "/mnt/c/Users/$USER/AppData/Roaming/Code/User/" ]]; then
-    # Copy Linux VSCode configuration to Windows VSCode
-    (
-      cd .config/Code/User/
-      for file in *.json; do
-        echo "Copying $file to Windows VSCode..."
-
-        # shellcheck disable=SC2016
-        echo '// Not symlinked; do `cd-dotfiles && ./install.sh` to update' \
-          >"/mnt/c/Users/$USER/AppData/Roaming/Code/User/$file"
-
-        cat "$file" >>"/mnt/c/Users/$USER/AppData/Roaming/Code/User/$file"
-      done
-      echo
-    )
-  fi
-fi
-
 if [[ -t 0 && -t 1 ]]; then    # stdin and stdout are both the terminal
   readonly pager=${PAGER-less} # default to `less` if $PAGER not set at all
 else                           # in pipeline or redirection


### PR DESCRIPTION
- Remove WSL-specific installation steps
- Remove WSL check for interactive open
- Remove WSL check for open-terminal
- Remove keychain usage as WSL ssh-agent
- Remove platform keybindings for VSCode
