### PR TITLE
Add overtype support to Visual Studio Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,9 @@
  */
 {
   "recommendations": [
+    /** Avail an overtype mode that is togglable by the `Insert` key. */
+    "drmerfy.overtype",
+
     /**
      * Provide autoformatting for markdown, JSON, YAML, and some others. See
      * `.prettierrc.yml` for options controlling autoformatting behavior.

--- a/home/.config/Code/User/keybindings.json
+++ b/home/.config/Code/User/keybindings.json
@@ -26,5 +26,12 @@
     "key": "shift+alt+up",
     "command": "-markdown.extension.onCopyLineUp" /* yzhang.markdown-all-in-one */,
     "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && editorLangId == 'markdown'"
+  },
+
+  /** Keybinding commonly overloaded; prefer `Insert` instead */
+  {
+    "key": "ctrl+shift+i",
+    "command": "-overtype.toggle",
+    "when": "editorFocus"
   }
 ]

--- a/home/.config/Code/User/settings.json
+++ b/home/.config/Code/User/settings.json
@@ -45,6 +45,10 @@
 
   "javascript.updateImportsOnFileMove.enabled": "always",
 
+  // `overtype` settings use the Overtype extension (`drmerfy.overtype`).
+  "overtype.paste": true,
+  "overtype.perEditor": true,
+
   // `python` settings use Microsoft's Python extension (`ms-python.python`) or
   // its Pylance dependency (`ms-python.vscode-pylance`).
   "python.analysis.typeCheckingMode": "strict",


### PR DESCRIPTION
- Add overtype extension as "recommended"
- Configure overtype behavior in editor
- Disable unneeded overtype keybinding
