### PR TITLE
Bash history size fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ warranty of any kind._
     extension; additionally, Python scripts are symlinked in kebab case (which
     is easier to type) rather than the in-repository snake case (which is
     `import`able)
+- many environments ship their own `~/.bashrc` with environment-specific items
+  and interoperability with those setups is done by not including `home/.bashrc`
+  here but rather relying on the fact that most `~/.bashrc` files will source
+  `~/.bash_aliases` if it exists, which _is_ included here; the `install.sh`
+  setup script can make minor tweaks to environment-provided `~/.bashrc` files
 - some items assume the presence of other things (e.g. a script might assume
   that certain `.gitconfig` aliases are configured or that another script can be
   called using its installed name), so partial installs might not work without

--- a/home/.bash_behavior
+++ b/home/.bash_behavior
@@ -13,7 +13,7 @@ if command -v vim &>/dev/null; then
   EDITOR=vim
 fi
 
-# Increase bash history size.
+# Increase bash history size; see dotfiles `install.sh` fixes to `~/.bashrc`.
 HISTSIZE=100000
 HISTFILESIZE=500000
 

--- a/install.sh
+++ b/install.sh
@@ -147,6 +147,15 @@ if [ "${CODESPACES-false}" == "true" ]; then
   echo
 fi
 
+# Bash will truncate history immediately upon assignment, even if number is
+# adjusted upward later by `~/.bash_behavior`, so comment out such assignments
+# in `~/.bashrc` if we see them.
+if grep -qE '^HIST(FILE)?SIZE=[0-9]+' ~/.bashrc; then
+  echo 'Commenting out history size variables in ~/.bashrc'
+  sed -Ei 's/^(HIST(FILE)?SIZE=[0-9]+)/# \1/' ~/.bashrc
+  echo
+fi
+
 if [[ -t 0 && -t 1 ]]; then    # stdin and stdout are both the terminal
   readonly pager=${PAGER-less} # default to `less` if $PAGER not set at all
 else                           # in pipeline or redirection


### PR DESCRIPTION
- install: comment-out history size variables
- .bash_behavior: call out install.sh tweak
- doc: explain .bashrc rationale
